### PR TITLE
🐛 Manage users without filters

### DIFF
--- a/cumplo_spotter/__init__.py
+++ b/cumplo_spotter/__init__.py
@@ -2,4 +2,4 @@
 A simple yet powerful API for spotting secure and high-return Cumplo investment opportunities
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/cumplo_spotter/routers/funding_requests/private.py
+++ b/cumplo_spotter/routers/funding_requests/private.py
@@ -5,13 +5,12 @@ from logging import getLogger
 from typing import cast
 
 from cumplo_common.integrations.cloud_pubsub import publish_event
-from cumplo_common.models.funding_request import FundingRequest
 from cumplo_common.models.user import User
 from fastapi import APIRouter
 from fastapi.requests import Request
 
 from cumplo_spotter.business import funding_requests
-from cumplo_spotter.utils.constants import AVAILABLE_FUNDING_REQUESTS_TOPIC, PROMISING_FUNDING_REQUESTS_TOPIC
+from cumplo_spotter.utils.constants import AVAILABLE_FUNDING_REQUESTS_TOPIC
 
 logger = getLogger(__name__)
 
@@ -30,25 +29,3 @@ def _fetch_funding_requests(request: Request) -> None:
 
     if content := [funding_request.json() for funding_request in available_funding_requests]:
         publish_event(content, AVAILABLE_FUNDING_REQUESTS_TOPIC, id_user=str(user.id))
-
-
-@router.post(path="/filter", status_code=HTTPStatus.NO_CONTENT)
-def _filter_funding_requests(request: Request, payload: list[FundingRequest]) -> None:
-    """
-    Filters a list of funding requests based on the user's filters.
-    """
-    user = cast(User, request.state.user)
-
-    promising_funding_requests = set()
-    for filters in user.filters.values():
-        promising_funding_requests.update(funding_requests.filter_(list(payload), filters))
-
-    if not promising_funding_requests:
-        logger.info(f"No promising funding requests for user {user.id}")
-        return
-
-    logger.info(f"Found {len(promising_funding_requests)} promising funding requests for user {user.id}")
-
-    for funding_request in promising_funding_requests:
-        logger.info(f"Notifying about funding request {funding_request.id} to user {user.id}")
-        publish_event(funding_request.json(), PROMISING_FUNDING_REQUESTS_TOPIC, id_user=str(user.id))

--- a/cumplo_spotter/routers/funding_requests/public.py
+++ b/cumplo_spotter/routers/funding_requests/public.py
@@ -4,11 +4,14 @@ from http import HTTPStatus
 from logging import getLogger
 from typing import cast
 
+from cumplo_common.integrations.cloud_pubsub import publish_event
+from cumplo_common.models.funding_request import FundingRequest
 from cumplo_common.models.user import User
 from fastapi import APIRouter
 from fastapi.requests import Request
 
 from cumplo_spotter.business import funding_requests
+from cumplo_spotter.utils.constants import PROMISING_FUNDING_REQUESTS_TOPIC
 
 logger = getLogger(__name__)
 
@@ -33,3 +36,25 @@ def _get_promising_funding_requests(request: Request) -> list[dict]:
     user = cast(User, request.state.user)
     promising_funding_requests = funding_requests.get_promising(user)
     return [request.json() for request in promising_funding_requests]
+
+
+@router.post(path="/filter", status_code=HTTPStatus.NO_CONTENT)
+def _filter_funding_requests(request: Request, payload: list[FundingRequest]) -> None:
+    """
+    Filters a list of funding requests based on the user's filters.
+    """
+    user = cast(User, request.state.user)
+    promising_funding_requests = set() if user.filters else set(payload)
+
+    for filter_ in user.filters.values():
+        promising_funding_requests.update(funding_requests.filter_(list(payload), filter_))
+
+    if not promising_funding_requests:
+        logger.info(f"No promising funding requests for user {user.id}")
+        return
+
+    logger.info(f"Found {len(promising_funding_requests)} promising funding requests for user {user.id}")
+
+    for funding_request in promising_funding_requests:
+        logger.info(f"Notifying about funding request {funding_request.id} to user {user.id}")
+        publish_event(funding_request.json(), PROMISING_FUNDING_REQUESTS_TOPIC, id_user=str(user.id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cumplo-spotter"
-version = "1.1.0"
+version = "1.1.1"
 description = "A simple yet powerful API for spotting secure and high-return Cumplo investment opportunities"
 authors = ["Cristobal Sfeir <cnsfeir@uc.cl>"]
 packages = [{ include = "cumplo_spotter" }]


### PR DESCRIPTION
##  📥  Issues
- [Distribute user funding requests with the admin API key instead of the user’s](https://www.notion.so/cnsfeir/Distribute-user-funding-requests-with-the-admin-API-key-instead-of-the-user-s-f76de5da960446a39a7733a1fd510acd?pvs=4)
- [Notify all funding requests if the user has no filters](https://www.notion.so/cnsfeir/Notify-all-funding-requests-if-the-user-has-no-filters-8d363aaaf66b44bbae0df05da855815b?pvs=4)

##  🔄  Changes

- Distribute user funding requests with the admin API key instead of the user’s
- Notify all funding requests if the user has no filters