### PR TITLE
ci: Add PR-title validation workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate conventional commit format
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^[A-Z].+$
+          subjectPatternError: >
+            The subject must start with an uppercase letter.
+            Example: "feat: Add new MCP tool"


### PR DESCRIPTION
Adds \`.github/workflows/pr-title.yml\` — validates that every PR title is a conventional commit (via amannn/action-semantic-pull-request@v5).

Pairs with the repo merge-commit settings (merge_commit_title=PR_TITLE, squash_merge_commit_title=PR_TITLE) so the enforced PR title becomes the permanent commit title.

Config applied verbatim from the standard org convention:
- types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
- requireScope: false
- subjectPattern: ^[A-Z].+$ (subject must start uppercase)