### PR TITLE
chore: Pin cumplo-common to ^1.12.10

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2192,4 +2192,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.5.0)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "5b2318b5f2fe82007724038c914e214b2bf0e26f558c35f822b65488b7811890"
+content-hash = "fa8ffef2bb0f8f03b7a31f0e082ed1dae04b52c0d1953b49c8ca7ecb0c74bcb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ retry = "^0.9.2"
 lxml = "^4.9.2"
 google-cloud-logging = "^3.5.0"
 httpx = "^0.26.0"
-cumplo-common = { version = "^1.12.7", source = "cumplo-pypi" }
+cumplo-common = { version = "^1.12.10", source = "cumplo-pypi" }
 cachetools = "^5.5.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
**Why:** Explicit lower-bound bump to match the confirmed v1.12.10 release in Artifact Registry (NOT-612). The lock was already resolved to 1.12.10; this aligns the declared constraint with what is actually pinned.
**Issue:** Refs NOT-613
**Notes for reviewer:** Only pyproject.toml (constraint line) and poetry.lock (content-hash) change — no code touched. CI lint covers this; no blast radius beyond this repo.