### PR TITLE
fix: Update CODEOWNERS to valid org member @cnsfeir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Not Cumplo audit gate
-* @cnsfeir-reviewer
+* @cnsfeir


### PR DESCRIPTION
**Why:** `@cnsfeir-reviewer` is not an org member, so the required-review gate it backs is currently ineffective; `@cnsfeir` is the valid org owner.
**Issue:** Refs NOT-688
**Notes for reviewer:** Single-line CODEOWNERS change only — no code logic touched. CI covers it.